### PR TITLE
option to disable sdl_gamecontrollerconfig

### DIFF
--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -684,6 +684,10 @@
       <choice name="Off" value="0" />
       <choice name="On" value="1" />
     </feature>
+    <feature name="SDL_GAMECONTROLLERCONFIG" value="ryu_sdl_game_controller_config" description="Use SDL_GAMECONTROLLERCONFIG from Batocera Auto=On. Turn it Off to use Xbox Series X Controllers.">
+      <choice name="Off" value="0" />
+      <choice name="On" value="1" />
+    </feature>
     <feature name="ENABLE CONTROLLER RUMBLE" value="ryu_enable_rumble" description="Auto Controller Configuration Auto=On ">
       <choice name="Off" value="0" />
       <choice name="On" value="1" />

--- a/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
+++ b/system/switch/configgen/generators/ryujinx/ryujinxMainlineGenerator.py
@@ -74,11 +74,13 @@ class RyujinxMainlineGenerator(Generator):
             else:
                 commandArray = ["/userdata/system/switch/Ryujinx.AppImage" , rom]
         eslog.debug("Controller Config before Playing: {}".format(controllersConfig.generateSdlGameControllerConfig(playersControllers)))
-        #, "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)
-        return Command.Command(
-            array=commandArray,
-            env={"XDG_CONFIG_HOME":RyujinxHome, "XDG_CACHE_HOME":batoceraFiles.CACHE, "QT_QPA_PLATFORM":"xcb", "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)}
-            )
+        # X Bos series X gamepads with dongle are very problematic
+        if ((system.isOptSet('ryu_sdl_game_controller_config') and not (system.config['ryu_sdl_game_controller_config'] == '0')) or not system.isOptSet('ryu_sdl_game_controller_config')): 
+            env_commandArray={"XDG_CONFIG_HOME":RyujinxHome, "XDG_CACHE_HOME":batoceraFiles.CACHE, "QT_QPA_PLATFORM":"xcb", "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)}            
+        else:
+            env_commandArray={"XDG_CONFIG_HOME":RyujinxHome, "XDG_CACHE_HOME":batoceraFiles.CACHE, "QT_QPA_PLATFORM":"xcb"}
+        
+        return Command.Command(array=commandArray, env=env_commandArray)
 
     def writeRyujinxConfig(RyujinxConfigFile, system, playersControllers):
 
@@ -294,7 +296,8 @@ class RyujinxMainlineGenerator(Generator):
         shown_file_types['nso'] = bool('true')
         data['shown_file_types'] = shown_file_types 
 
-        if ((system.isOptSet('ryu_auto_controller_config') and not (system.config["ryu_auto_controller_config"] == "0")) or not system.isOptSet('ryu_auto_controller_config')):
+
+        if ((system.isOptSet('ryu_auto_controller_config') and not (system.config['ryu_auto_controller_config'] == '0')) or not system.isOptSet('ryu_auto_controller_config')):
             
             filename = "/userdata/system/switch/configgen/debugcontrollers.txt"
             if os.path.exists(filename):


### PR DESCRIPTION
Using a xbox series x controller with the dongle is complicated with ryujinx: some buttons don't map.
The workaround consists in turnin off both auto config of the controller and removing SDL_GAMECONTROLLERCONFIG from the launch parameters.
I'd like to push this PR for my own benefit, but also for users that I see on discord, facing the exact same problem.

