### PR TITLE
updated for eden 0.0.4

### DIFF
--- a/system/configs/emulationstation/es_features_switch.cfg
+++ b/system/configs/emulationstation/es_features_switch.cfg
@@ -31,7 +31,7 @@
       <choice name="Stereo (default)" value="1" />
       <choice name="Surround" value="2" />
     </feature>
-    <feature name="GRAPHICS BACKEND" value="yuzu_backend" description="Choose your graphics rendering">
+    <feature name="GRAPHICS BACKEND" value="yuzu_backend" description="Choose your graphics rendering Auto=Vulkan">
       <choice name="Opengl" value="0" />
       <choice name="Vulkan" value="1" />
     </feature>
@@ -40,7 +40,7 @@
       <choice name="Glasm (nvidia only)" value="1" />
       <choice name="Spir-v (mesa only)" value="2" />
     </feature>
-    <feature name="ASYNC SHADER" value="async_shaders" description="Speedup shader compilation">
+    <feature name="ASYNC SHADER" value="async_shaders" description="Speedup shader compilation Auto=On">
       <choice name="Off" value="false" />
       <choice name="On" value="true" />
     </feature>
@@ -49,14 +49,15 @@
       <choice name="0.50x (360p/540p)[experimental]" value="1" />
       <choice name="0.75x (540p/810p)[experimental]" value="2" />
       <choice name="1x (720p/1080p)" value="3" />
-      <choice name="1.5x (1080/1620p)[experimental]" value="4" />
-      <choice name="2x (1440p/2160p)" value="5" />
-      <choice name="3x (2160p/3240p)" value="6" />
-      <choice name="4x (2880p/4320p)" value="7" />
-      <choice name="5x (3600p/5400p)" value="8" />
-      <choice name="6x (4320p/6480p)" value="9" />
-      <choice name="7x (5040p/7560p)" value="10" />
-      <choice name="8x (5760p/8640p)" value="11" />
+      <choice name="1.25x (900/1350p)[experimental]" value="4" />
+      <choice name="1.5x (1080/1620p)[experimental]" value="5" />
+      <choice name="2x (1440p/2160p)" value="6" />
+      <choice name="3x (2160p/3240p)" value="7" />
+      <choice name="4x (2880p/4320p)" value="8" />
+      <choice name="5x (3600p/5400p)" value="9" />
+      <choice name="6x (4320p/6480p)" value="10" />
+      <choice name="7x (5040p/7560p)" value="11" />
+      <choice name="8x (5760p/8640p)" value="12" />
     </feature>
     <feature name="SINGLE WINDOW MODE" value="single_window" description="Single Window Mode setting Auto=On">
       <choice name="On" value="true" />
@@ -77,10 +78,12 @@
       <choice name="Bilinear" value="1" />
       <choice name="Bicubic" value="2" />
       <choice name="Gaussian" value="3" />
-      <choice name="ScaleForce" value="4" />
-      <choice name="AMD's FidelityFX Super Resolution [Vulkan Only]" value="5" />
+      <choice name="Lanczos" value="4" />
+      <choice name="ScaleForce" value="5" />
+      <choice name="AMD's FidelityFX Super Resolution [Vulkan Only]" value="6" />
+      <choice name="MMPX [Only works for pixel-art]]" value="12" />
     </feature>
-    <feature name="FXAA/SMAA" value="aliasing_method" description="Anti aliasing FXAA/SMAA">
+    <feature name="FXAA/SMAA" value="aliasing_method" description="Anti aliasing FXAA/SMAA Auto=Off">
       <choice name="Off" value="0" />
       <choice name="Fxaa" value="1" />
       <choice name="Smaa" value="2" />
@@ -89,20 +92,21 @@
       <choice name="Off" value="false" />
       <choice name="On" value="true" />
     </feature>
-    <feature name="ASYNC GPU EMULATION" value="async_gpu" description="Asynchronous gpu emulation">
+    <feature name="ASYNC GPU EMULATION" value="async_gpu" description="Asynchronous gpu emulation Auto=On">
       <choice name="Off" value="false" />
       <choice name="On" value="true" />
     </feature>
-    <feature name="GPU CACHE GC" value="gpu_cache_gc" description="Enables garbage collection for gpu cache">
+    <feature name="GPU CACHE GC" value="gpu_cache_gc" description="Enables garbage collection for gpu cache Auto=Off">
       <choice name="Off" value="false" />
       <choice name="On" value="true" />
     </feature>
-    <feature name="GPU ACCURACY" value="gpuaccuracy" description="Gpu accuracy level">
-      <choice name="Normal" value="0" />
-      <choice name="High" value="1" />
-      <choice name="Extreme" value="2" />
+    <feature name="GPU ACCURACY" value="gpuaccuracy" description="Gpu accuracy level Auto=Performance">
+      <choice name="Performance" value="0" />
+      <choice name="Balanced" value="1" />
+      <choice name="Accurate" value="2" />
     </feature>
-    <feature name="CPU ACCURACY" value="cpuaccuracy" description="Cpu accuracy level">
+    <feature name="CPU ACCURACY" value="cpuaccuracy" description="Cpu accuracy level Auto=Automatic">
+      <choice name="Automatic" value="0" />
       <choice name="Accurate" value="1" />
       <choice name="Unsafe" value="2" />
     </feature>

--- a/system/switch/configgen/generators/eden/edenGenerator.py
+++ b/system/switch/configgen/generators/eden/edenGenerator.py
@@ -364,7 +364,7 @@ class EdenGenerator(Generator):
         if system.isOptSet('yuzu_backend'):
             yuzuConfig.set("Renderer", "backend", system.config["yuzu_backend"])
         else:
-            yuzuConfig.set("Renderer", "backend", "0")
+            yuzuConfig.set("Renderer", "backend", "1")
         yuzuConfig.set("Renderer", "backend\\default", "false")
 
         # Async Shader compilation


### PR DESCRIPTION
1. Due to added options in eden 0.0.4 (eg: x1.25 resolution upscale), some values have to be adjusted.
2. Vulkan should be the preferred default backend due to superior shader compilation speed.