### PR TITLE
Allow to exit Ryujinx from the controller by inputing Hotkey+Start

### DIFF
--- a/system/configs/evmapy/switch.keys
+++ b/system/configs/evmapy/switch.keys
@@ -6,7 +6,7 @@
                 "start"
             ],
             "type": "exec",
-            "target": ["unclutter-remote -h && killall -9 eden sudachi sudachi-room Sudachi citron Citron citron.AppImage AppRun.wrapped suyu suyu.AppImage suyu-room yuzu yuzu-room yuzuEA yuzu.AppImage yuzuEA.AppImage 2>/dev/null"]
+            "target": ["unclutter-remote -h && killall -9 eden sudachi sudachi-room Sudachi citron Citron citron.AppImage AppRun.wrapped suyu suyu.AppImage suyu-room yuzu yuzu-room yuzuEA yuzu.AppImage yuzuEA.AppImage Ryujinx.AppImage 2>/dev/null"]
         },
         {
             "trigger": ["hotkey", "start"],


### PR DESCRIPTION
I've seen this was deleted 3 months ago, resulting in the inability to exit Ryujinx with just a gamepad (I've seen other people on discord reporting the same problem).
This simple solution works fine on my system for now, making ryujinx usage a bit more convenient.

